### PR TITLE
Auto-focus on load_val when loading data to memory

### DIFF
--- a/index.html
+++ b/index.html
@@ -971,6 +971,7 @@ H - highest 4 bits of address (rows)        L - lowest 4 bits of address (column
 			
 			INPUT_ADDR.value = ("00" + ((parseInt(INPUT_ADDR.value, 16) + 1) % 0x100).toString(16).toUpperCase()).substr(-2); // Increment ADDR
 			this.updateLoadAddrPosition();
+			document.getElementById("load_val").focus()
         }
 		
 		updateLoadAddrPosition()

--- a/index.html
+++ b/index.html
@@ -972,6 +972,7 @@ H - highest 4 bits of address (rows)        L - lowest 4 bits of address (column
 			INPUT_ADDR.value = ("00" + ((parseInt(INPUT_ADDR.value, 16) + 1) % 0x100).toString(16).toUpperCase()).substr(-2); // Increment ADDR
 			this.updateLoadAddrPosition();
 			document.getElementById("load_val").focus()
+			document.getElementById("load_val").select()
         }
 		
 		updateLoadAddrPosition()


### PR DESCRIPTION
When inputting a lot of instructions from a table to the simulator, it takes a long time to click the input field manually over and over again.
This proposed change attempts to avoid the issue by auto-focusing on the input field after an accepted input value.